### PR TITLE
Consistent binary name for noderesourcetopology plugin

### DIFF
--- a/build/noderesourcetopology-plugin/Dockerfile
+++ b/build/noderesourcetopology-plugin/Dockerfile
@@ -22,7 +22,7 @@ RUN RELEASE_VERSION=${RELEASE_VERSION} make build-noderesourcetopology-plugin
 
 FROM $ARCH/alpine:3.12
 
-COPY --from=0 /go/src/sigs.k8s.io/scheduler-plugins/bin/noderesourcetopology-plugin /bin/noderesourcetopology-plugin
+COPY --from=0 /go/src/sigs.k8s.io/scheduler-plugins/bin/noderesourcetopology-plugin /bin/kube-scheduler
 
 WORKDIR /bin
-CMD ["noderesourcetopology-plugin"]
+CMD ["kube-scheduler"]


### PR DESCRIPTION
In the favour of consistency and making sure that the noderesourcetopology
plugin works with the existing deployment files, we keep the binary name
same as the one used for other scheduler plugins i.e kube-scheduler.
    
In a lot of instances, the sys admin might want to provide additional
arguments or override the existing defaults in the deployment spec and
it is better to have the binary name same as the one used in case of
other scheduler plugins.
    
Signed-off-by: Swati Sehgal <swsehgal@redhat.com>