### PR TITLE
Fix dockerfile

### DIFF
--- a/build/noderesourcetopology-plugin/Dockerfile
+++ b/build/noderesourcetopology-plugin/Dockerfile
@@ -11,13 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-ARG ARCH
+
 FROM golang:1.17 as builder
 
 WORKDIR /go/src/sigs.k8s.io/scheduler-plugins
 COPY . .
 
-ARG ARCH
 ARG RELEASE_VERSION
 RUN RELEASE_VERSION=${RELEASE_VERSION} make build-noderesourcetopology-plugin
 

--- a/build/noderesourcetopology-plugin/Dockerfile
+++ b/build/noderesourcetopology-plugin/Dockerfile
@@ -24,4 +24,5 @@ RUN RELEASE_VERSION=${RELEASE_VERSION} make build-noderesourcetopology-plugin
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 COPY --from=builder /go/src/sigs.k8s.io/scheduler-plugins/bin/noderesourcetopology-plugin /bin/kube-scheduler
 USER 65532:65532
-ENTRYPOINT ["/bin/kube-scheduler"]
+WORKDIR /bin
+CMD ["kube-scheduler"]


### PR DESCRIPTION
We previously added the ENTRYPOINT in the Dockerfile in commit 4f30fb2 , but turns out this is incompatible with the configuration the secondary-scheduler-operator injects, so we revert the change.
