### PR TITLE
makefile: add a target to run a subset of tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,10 @@ update-vendor:
 unit-test: autogen
 	hack/unit-test.sh
 
+.PHONY: unit-test-quick
+unit-test-quick:
+	hack/unit-test-quick.sh
+
 .PHONY: install-etcd
 install-etcd:
 	hack/install-etcd.sh

--- a/hack/unit-test-quick.sh
+++ b/hack/unit-test-quick.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# this script focus on the narrow subset of the unit tests we
+# support. To run the full suite, use `unit-test.sh`
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${SCRIPT_ROOT}/hack/lib/init.sh"
+
+# TODO: make args customizable.
+go test -mod=vendor \
+  sigs.k8s.io/scheduler-plugins/cmd/noderesourcetopology-plugin/... \
+  sigs.k8s.io/scheduler-plugins/pkg/noderesourcetopology/...


### PR DESCRIPTION
We focus on a subset of plugins, so it makes sense
to also define a subset of tests we consider tier 1
and run them first in our CI.

Signed-off-by: Francesco Romani <fromani@redhat.com>